### PR TITLE
Correct the spelling of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Simply run `pod try DOCheckboxControl`
 
 ## Requirements
 
-- XCode 6.4
+- Xcode 6.4
 - Swift 1.2
 - iOS 8.0
 


### PR DESCRIPTION
This pull request corrects the spelling of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
